### PR TITLE
Fix deprecate static call on non-static function

### DIFF
--- a/lib/avro/data_file.php
+++ b/lib/avro/data_file.php
@@ -164,7 +164,7 @@ class AvroDataIO
    * @param AvroSchema $schema
    * @return AvroDataIOWriter
    */
-  protected function open_writer($io, $schema)
+  protected static function open_writer($io, $schema)
   {
     $writer = new AvroIODatumWriter($schema);
     return new AvroDataIOWriter($io, $writer, $schema);
@@ -175,7 +175,7 @@ class AvroDataIO
    * @param AvroSchema $schema
    * @return AvroDataIOReader
    */
-  protected function open_reader($io, $schema)
+  protected static function open_reader($io, $schema)
   {
     $reader = new AvroIODatumReader(null, $schema);
     return new AvroDataIOReader($io, $reader);


### PR DESCRIPTION
PHP 7 on my machine telling me about 2 deprecated function calls in data_file.php.

open_writer()
open_reader()

as static function. A minor supplement with `static` keyword help to clear out this issue.

Please see if you can accept my fix. Thanks